### PR TITLE
Build JavaScript assets when running npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"description": "Mayhem. A framework for rich Internet applications.",
 	"dojoBuild": "package.js",
 	"scripts": {
-		"install": "bower install"
+		"install": "bower install && grunt build"
 	},
 	"devDependencies": {
 		"globule": "0.2.0",


### PR DESCRIPTION
Building the assets will simplify the getting started instructions and will remove a setup step.
