### PR TITLE
Container: fix parentNode insertion to use correct parentNode reference

### DIFF
--- a/ui/dom/Container.ts
+++ b/ui/dom/Container.ts
@@ -34,9 +34,8 @@ class Container extends MultiNodeWidget implements IContainer {
 
 		var nextWidget:Widget = this._children[position];
 		var nextNode:Node = nextWidget ? nextWidget.get('firstNode') : this._lastNode;
-		var parentNode:Node = nextNode || this._firstNode.parentNode;
 
-		parentNode.insertBefore(child.detach(), nextNode);
+		nextNode.parentNode.insertBefore(child.detach(), nextNode);
 		ContainerMixin.prototype.add.call(this, child);
 
 		var self = this;


### PR DESCRIPTION
nodeA.insertBefore(newNode, nodeB) is only ever valid when nodeA===nodeB
