### PR TITLE
Add 'filter' and 'sort' to data/Proxy wrapCollection

### DIFF
--- a/src/data/Proxy.ts
+++ b/src/data/Proxy.ts
@@ -56,6 +56,14 @@ class Proxy<T> extends Base {
 				};
 			}
 
+			wrapperCollection.sort = function () {
+				return wrapCollection(collection.sort.apply(collection, arguments));
+			};
+
+			wrapperCollection.filter = function () {
+				return wrapCollection(collection.filter.apply(collection, arguments));
+			};
+
 			wrapperCollection.fetch = function () {
 				return collection.fetch.apply(collection, arguments).then(function (items: T[]) {
 					return items.map(createProxy);


### PR DESCRIPTION
without these two additions, calling 'filter' or 'sort' on the proxied collection will not work properly. 