### PR TITLE
DijitWidget: Focus focusNode instead of domNode if it exists

### DIFF
--- a/src/ui/dom/DijitWidget.ts
+++ b/src/ui/dom/DijitWidget.ts
@@ -55,7 +55,7 @@ class DijitWidget extends SingleNodeWidget {
 		return this._isFocused;
 	}
 	_isFocusedSetter(value:boolean):void {
-		value && this._widget.domNode.focus();
+		value && (this._widget.focusNode || this._widget.domNode).focus();
 		this._isFocused = value;
 	}
 

--- a/typings/dojo/dijit.d.ts
+++ b/typings/dojo/dijit.d.ts
@@ -297,6 +297,7 @@ declare module 'dijit/_WidgetBase' {
 	interface _WidgetBase extends Stateful, Evented, Destroyable {
 		/* readonly */ containerNode?:HTMLElement;
 		/* readonly */ domNode:HTMLElement;
+		/* readonly */ focusNode?:HTMLElement;
 
 		new (kwArgs?:Object, srcNodeRef?:HTMLElement):_WidgetBase;
 


### PR DESCRIPTION
Currently, the `isFocused` setter logic in `DijitWidget` always tries to focus `domNode`, which isn't very helpful for input widgets like `Text`.  This fixes that by checking for `focusNode` first and only falling back to `domNode` if that doesn't exist.